### PR TITLE
Add --nogroup flag to hide group

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -13,6 +13,7 @@ type arguments struct {
 	bytes     *bool
 	mdate     *bool
 	owner     *bool
+	nogroup   *bool
 	perms     *bool
 	long      *bool
 	dirs      *bool
@@ -36,6 +37,7 @@ var args = arguments{
 	kingpin.Flag("bytes", "include size").Short('b').Bool(),
 	kingpin.Flag("mdate", "include modification date").Short('m').Bool(),
 	kingpin.Flag("owner", "include owner and group").Short('o').Bool(),
+	kingpin.Flag("nogroup", "hide group").Short('N').Bool(),
 	kingpin.Flag("perms", "include permissions for owner, group, and other").Short('p').Bool(),
 	kingpin.Flag("long", "include size, date, owner, and permissions").Short('l').Bool(),
 	kingpin.Flag("dirs", "only show directories").Short('d').Bool(),

--- a/ls-go.go
+++ b/ls-go.go
@@ -195,8 +195,12 @@ func listFiles(parentDir string, items *[]os.FileInfo, forceDotfiles bool) {
 
 		if *args.owner {
 			paddedOwner := pad.Right(owner, longestOwnerName, " ")
-			paddedGroup := pad.Right(group, longestGroupName, " ")
-			ownerInfo := []string{Reset + ownerColor + paddedOwner, groupColor + paddedGroup, Reset}
+			ownerInfo := []string{Reset + ownerColor + paddedOwner}
+			if !*args.nogroup {
+				paddedGroup := pad.Right(group, longestGroupName, " ")
+				ownerInfo = append(ownerInfo, groupColor+paddedGroup)
+			}
+			ownerInfo = append(ownerInfo, Reset)
 			displayItem.display += strings.Join(ownerInfo, " ")
 		}
 


### PR DESCRIPTION
Our groups come from Active Directory, and are rather long. This PR gives you the ability to display the owner but not the group, similar to exa <https://the.exa.website/>.

I opted for the `--nogroup,-N` flag to not break existing behavior of the `--owner,-o` flag.

Love this utility -- thanks! 