### PR TITLE
add option for selinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Flags:
   -i, --icons      show folder icon before dirs
   -n, --nerd-font  show nerd font glyphs before file names
   -r, --recurse    traverse all dirs recursively
+  -Z, --selinux    include security context
   -F, --find=FIND  filter items with a regexp
 
 Args:

--- a/arguments.go
+++ b/arguments.go
@@ -28,6 +28,7 @@ type arguments struct {
 	icons     *bool
 	nerdfont  *bool
 	recurse   *bool
+	selinux   *bool
 	find      *string
 }
 
@@ -52,6 +53,7 @@ var args = arguments{
 	kingpin.Flag("icons", "show folder icon before dirs").Short('i').Bool(),
 	kingpin.Flag("nerd-font", "show nerd font glyphs before file names").Short('n').Bool(),
 	kingpin.Flag("recurse", "traverse all dirs recursively").Short('r').Bool(),
+	kingpin.Flag("selinux", "include security context").Short('Z').Bool(),
 	kingpin.Flag("find", "filter items with a regexp").Short('F').String(),
 }
 


### PR DESCRIPTION
A build flag will need to be added: `go build -tags selinux`

Should the output of this also be colorized?

closes https://github.com/acarl005/ls-go/issues/6